### PR TITLE
Forcing --no-colors when running tests

### DIFF
--- a/App/Lib/Codeception.php
+++ b/App/Lib/Codeception.php
@@ -248,6 +248,7 @@ class Codeception
         $params = array(
             $this->config['executable'],        // Codeception Executable
             "run",                              // Command to Codeception
+            "--no-colors",                      // Forcing Codeception to not use colors, if enabled in codeception.yml
             "--config=\"{$this->site->getConfig()}\"", // Full path & file of Codeception
             $type,                              // Test Type (Acceptance, Unit, Functional)
             $filename,                          // Filename of the Codeception test


### PR DESCRIPTION
This ends with shell colour strings in web output. Closes #16
