### PR TITLE
Fix for Cest files containing more than one test.

### DIFF
--- a/App/Lib/Test.php
+++ b/App/Lib/Test.php
@@ -286,13 +286,15 @@ class Test
      */
     public function setLog($lines = array())
     {
+        $failed = false;
         foreach ($lines as $line) {
 
-            if ($this->checkLogForTestPass($line))
+            if ($this->checkLogForTestPass($line) && $failed==false)
                 $this->setPassed();
 
             if ($this->checkLogForTestFailure($line)) {
                 $this->setFailed();
+                $failed = true;
             }
 
             // Filter the line of any junk and add to the log.


### PR DESCRIPTION
I have made a small fix when there is more than one test on acceptance Cest file. 

Before my changes it echoed that test passed when there were only one test from Cest file that passes. What my change does, it checks if line fails and then sets passed to false, showing that test failed.
