### PR TITLE
Replace the file path with file_get_contents

### DIFF
--- a/App/Lib/Codeception.php
+++ b/App/Lib/Codeception.php
@@ -104,7 +104,7 @@ class Codeception
             return false;
 
         // Using Symfony's Yaml parser, the file gets turned into an array.
-        $config = \Symfony\Component\Yaml\Yaml::parse($full_path);
+        $config = \Symfony\Component\Yaml\Yaml::parse(file_get_contents($full_path));
 
         // Update the config to include the full path.
         foreach ($config['paths'] as $key => &$test_path) {


### PR DESCRIPTION
Yaml v3.0 parser needs the content of the file instead of the file path. 
This fixes an the ErrorException
