### PR TITLE
When loading tests, check if the test directory exists.

### DIFF
--- a/App/Lib/Codeception.php
+++ b/App/Lib/Codeception.php
@@ -130,8 +130,15 @@ class Codeception
             if (! $active)
                 break;
 
+            $testdir = "{$this->config['paths']['tests']}/{$type}/";
+
+            if (!is_dir($testdir)) {
+                // If no directory exists for the test type, continue
+                continue;
+            }
+
             $files = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator("{$this->config['paths']['tests']}/{$type}/", \FilesystemIterator::SKIP_DOTS),
+                new \RecursiveDirectoryIterator($testdir, \FilesystemIterator::SKIP_DOTS),
                 \RecursiveIteratorIterator::SELF_FIRST
             );
 


### PR DESCRIPTION
This prevents an uncaught exception if you have a test type in one site, and not another.

As an example, in Site #A, a user has an "acceptance" suite that they don't have in Site #B. When Codeception loadTests() is called, it iterates through the 'tests' array in config, in each site directory, and crashes if the directory doesn't exist.

Let me know if this needs more clarification.