### PR TITLE
Fix BUG - can't find test files on windows wamp.

### DIFF
--- a/App/Lib/Codeception.php
+++ b/App/Lib/Codeception.php
@@ -130,8 +130,8 @@ class Codeception
             if (! $active)
                 break;
 
-            $files = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator("{$this->config['paths']['tests']}/{$type}/", \FilesystemIterator::SKIP_DOTS),
+             $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->config['paths']['tests'].DIRECTORY_SEPARATOR.$type.DIRECTORY_SEPARATOR, \FilesystemIterator::SKIP_DOTS),
                 \RecursiveIteratorIterator::SELF_FIRST
             );
 

--- a/App/Lib/Test.php
+++ b/App/Lib/Test.php
@@ -140,7 +140,7 @@ class Test
     public function init($type, $file)
     {
         $filename       = $this->filterFileName($file->getFileName());
-        $posTypePath    = strpos($file->getPathname(), "/{$type}/") + strlen("/{$type}/");
+        $posTypePath    = strpos($file->getPathname(), DIRECTORY_SEPARATOR.$type.DIRECTORY_SEPARATOR) + strlen(DIRECTORY_SEPARATOR.$type.DIRECTORY_SEPARATOR);
 
         $this->hash     = $this->makeHash($type . $filename);
         $this->title    = $this->filterTitle($filename);

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ No. It's completely un-official. It's not affiliated or sponsored in anyway by t
 
 So, raise all issues about Webception on the Webception [GitHub Issues](https://github.com/jayhealey/Webception/issues) page.
 
+**How do I run webception in WAMP on windows?
+By default WAMP disables environment variables and the php executable cannot be found without the system path being available. 
+Enable environment variables by editing c:\wamp\bin\apache\apache2.4.9\bin\php.ini and ensure the line 
+variables_order = "EGPCS"
 ------------
 
 <a name='roadmap'></a>


### PR DESCRIPTION
1. Add comment to readme/faq about wamp installation environment variable causing failure to find php executable.

2. Fix bug - Can't find test files on windows wamp. Use DIRECTORY_SEPARATOR for generated paths.

