### PR TITLE
Default terminal commands to NOT use global $_ENV

### DIFF
--- a/App/Functions/helpers.php
+++ b/App/Functions/helpers.php
@@ -29,7 +29,7 @@ if (! function_exists('run_terminal_command')) {
 
         flush();
 
-        $process = proc_open($command, $spec, $pipes, realpath('./'), $_ENV);
+        $process = proc_open($command, $spec, $pipes, realpath('./'));
 
         if (is_resource($process)) {
 


### PR DESCRIPTION
This is mainly to prevent issues with inconsistency between PHP and the OS
