### PR TITLE
Move local configuration to file outside of version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 vendor
 package/codecept.phar
+App/config/codeception-local.php

--- a/App/Config/codeception-local-sample.php
+++ b/App/Config/codeception-local-sample.php
@@ -1,0 +1,22 @@
+<?php
+    /*
+    |--------------------------------------------------------------------------
+    | Local Configurations
+    |--------------------------------------------------------------------------
+    |
+    | Copy this file to 'codeception-local.php` (remove the 'sample'
+    | then this is where you add your own Webception configurations, this
+    | file should be excluded from your version control.
+    |
+    | See `codeception.php` for available configuration options, then override
+    | or merge them by adding them to this file. The array returned by
+    | this file will be recursivly merged with the array in that file.
+    |
+    | http://www.php.net/manual/en/function.array-merge-recursive.php
+    |
+    */
+return array(
+    'sites' => array(
+        // Add your own sites here
+    ),
+);

--- a/App/Config/codeception.php
+++ b/App/Config/codeception.php
@@ -1,6 +1,11 @@
 <?php
 
-return array(
+$localConfig = array();
+if (file_exists(__DIR__.'/codeception-local.php')) {
+    $localConfig = require(__DIR__.'/codeception-local.php');
+}
+
+return array_merge_recursive(array(
 
     /*
     |--------------------------------------------------------------------------
@@ -22,7 +27,6 @@ return array(
     'sites' => array(
 
         'Webception'         => dirname(__FILE__) .'/../../codeception.yml',
-
     ),
 
     /*
@@ -73,4 +77,4 @@ return array(
     */
 
     'location'   => __FILE__,
-);
+), $localConfig);

--- a/App/Config/codeception.php
+++ b/App/Config/codeception.php
@@ -1,5 +1,16 @@
 <?php
 
+    /*
+    |--------------------------------------------------------------------------
+    | Default Configurations
+    |--------------------------------------------------------------------------
+    |
+    | This file holds the default configurations for WebCeption. Rather than editing
+    | this file copy `codeception-local-sample.php` to `codeception-local.php` and
+    | update that file with your custom configs.
+    |
+    */
+
 $localConfig = array();
 if (file_exists(__DIR__.'/codeception-local.php')) {
     $localConfig = require(__DIR__.'/codeception-local.php');
@@ -25,7 +36,6 @@ return array_merge_recursive(array(
     */
 
     'sites' => array(
-
         'Webception'         => dirname(__FILE__) .'/../../codeception.yml',
     ),
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Out of the box, Webception is configured to run it's own Codeception tests.
 
 You'll need [Composer](http://getcomposer.org/download/) to be installed and the Codeception executable and logs directory need full read/write permissions.
 
-The *only* configuration file you need to update is `App/Config/codeception.php`. It's here where you add references to the `codeception.yml` configurations.
+The *only* configuration file you need to update is `App/Config/codeception-local.php` which you should create by copying `App/Config/codeception-local-sample.php`. It's here where you add references to the `codeception.yml` configurations.
 
 Also note Webception's `codeception.yml` is setup to use `http://webception:80` as it's host. Change this to be whatever host and port you decide to run Webception on.
 


### PR DESCRIPTION
For two reasons:

* I wanted to be able to keep CodeCeption connected to the repo so I can recieve updates and fix bugs where possible
* It's generally a good idea to keep deployment specific configs out of source control

Rather than editing `codeception.php` local config can now be placed in `codeception-local.php` (and a template `codeception-local-sample.php` has been provided) which will be ignored by git.