### PR TITLE
fix of loading tests when one of the tests is inactive

### DIFF
--- a/App/Lib/Codeception.php
+++ b/App/Lib/Codeception.php
@@ -128,7 +128,7 @@ class Codeception
             // If the test type has been disabled in the Webception config,
             //      skip processing the directory read for those tests.
             if (! $active)
-                break;
+                continue;
 
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator("{$this->config['paths']['tests']}/{$type}/", \FilesystemIterator::SKIP_DOTS),


### PR DESCRIPTION
When I set one of test inclusions to false in App/Config/codeception.php, it stops the loading of tests.
The excepted behaviour is to skip the tests marked fith false and load all the others.